### PR TITLE
Improve examples styling

### DIFF
--- a/app/examples/custom-validation/page.mdx
+++ b/app/examples/custom-validation/page.mdx
@@ -4,15 +4,13 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-<div className="container py-6 lg:py-10">
-  <div className="flex items-center gap-4 mb-8">
-    <Link href="/examples">
-      <Button variant="outline" size="icon">
-        <ArrowLeft className="h-4 w-4" />
-      </Button>
-    </Link>
-    <h1 className="text-3xl font-bold tracking-tight">表单验证规则定制示例</h1>
-  </div>
+<Link href="/examples">
+  <Button variant="outline" size="icon">
+    <ArrowLeft className="h-4 w-4" />
+  </Button>
+</Link>
+
+# 表单验证规则定制示例
 
   <div className="my-8 space-y-6">
     <div className="space-y-4">
@@ -219,4 +217,3 @@ import { Button } from "@/components/ui/button";
       - 🔄 **可扩展设计**：便于添加新的验证规则和修改现有规则
     </div>
   </div>
-</div> 

--- a/app/examples/layout.tsx
+++ b/app/examples/layout.tsx
@@ -14,8 +14,12 @@ export default function ExamplesLayout({
 }) {
   return (
     <div className="flex-1">
-      <ClientCodeHighlighter />
-      {children}
+      <div className="container py-6 lg:py-10">
+        <div className="prose dark:prose-invert mx-auto w-full min-w-0">
+          <ClientCodeHighlighter />
+          {children}
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/examples/page.mdx
+++ b/app/examples/page.mdx
@@ -6,38 +6,21 @@ export const metadata = {
   description: "浏览我们的示例集合，了解如何有效使用kinlink。",
 };
 
-<div className="container py-6 lg:py-10">
-  <div className="flex flex-col items-start gap-4 md:flex-row md:justify-between md:gap-8">
-    <div className="flex-1 space-y-4">
-      <h1 className="inline-block font-heading text-4xl tracking-tight lg:text-5xl">
-        示例
-      </h1>
-      <div className="text-xl text-muted-foreground">
-        浏览我们的示例集合，了解如何有效使用kinlink。
-      </div>
-    </div>
-  </div>
+# 示例
 
-  <div className="my-8">
-    <ExamplesClient />
-  </div>
+浏览我们的示例集合，了解如何有效使用kinlink。
 
-  <div className="mt-12 space-y-4">
-    <h2 className="text-2xl font-bold tracking-tight">需要自定义示例？</h2>
-    <div className="text-muted-foreground">
-      找不到您需要的内容？我们的团队可以帮助您创建根据您特定需求定制的示例。
-    </div>
-    <div className="flex flex-col sm:flex-row gap-4 mt-4">
-      <Button asChild>
-        <a href="https://www.kintone.cn/">
-          联系支持
-        </a>
-      </Button>
-      <Button variant="outline" asChild>
-        <a href="/docs">
-          查看文档
-        </a>
-      </Button>
-    </div>
-  </div>
-</div> 
+<ExamplesClient />
+
+## 需要自定义示例？
+
+找不到您需要的内容？我们的团队可以帮助您创建根据您特定需求定制的示例。
+
+<div className="flex flex-col sm:flex-row gap-4 mt-4">
+  <Button asChild>
+    <a href="https://www.kintone.cn/">联系支持</a>
+  </Button>
+  <Button variant="outline" asChild>
+    <a href="/docs">查看文档</a>
+  </Button>
+</div>


### PR DESCRIPTION
## Summary
- adjust examples layout to use prose styling like docs
- convert main examples page to markdown headings
- start converting example subpages (custom validation) to markdown

## Testing
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_b_6844dcdc398c8323b616cc0561e91594